### PR TITLE
Fix missing file extensions

### DIFF
--- a/Otopack+ModsUpdates BN/Mods/BL9+Secronom/furniture_effects.json
+++ b/Otopack+ModsUpdates BN/Mods/BL9+Secronom/furniture_effects.json
@@ -62,9 +62,9 @@
     "variant": "f_secro_flower_flesh",
     "volume": 30,
     "files": [
-      "terrain/fungal/smash_fungal_1",
-	  "terrain/fungal/smash_fungal_2",
-	  "terrain/fungal/smash_fungal_3"
+      "terrain/fungal/smash_fungal_1.ogg",
+	  "terrain/fungal/smash_fungal_2.ogg",
+	  "terrain/fungal/smash_fungal_3.ogg"
     ]
   },
   {

--- a/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_22.json
+++ b/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_22.json
@@ -31,11 +31,11 @@
         "volume" : 75,
         "variant" : "rm360_carbine",
         "files" : [
-            "guns/reload/rifle_m/rifle_1",
-			"guns/reload/rifle_m/rifle_2",
-			"guns/reload/rifle_m/rifle_3",
-			"guns/reload/rifle_m/rifle_4",
-			"guns/reload/rifle_m/rifle_5"
+            "guns/reload/rifle_m/rifle_1.ogg",
+			"guns/reload/rifle_m/rifle_2.ogg",
+			"guns/reload/rifle_m/rifle_3.ogg",
+			"guns/reload/rifle_m/rifle_4.ogg",
+			"guns/reload/rifle_m/rifle_5.ogg"
         ]
     }
 ]

--- a/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_223.json
+++ b/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_223.json
@@ -227,11 +227,11 @@
         "volume" : 75,
         "variant" : "l_lmg_223",
         "files" : [
-            "guns/reload/mg/mgk_1",
-			"guns/reload/mg/mgk_2",
-			"guns/reload/mg/mgk_3",
-			"guns/reload/mg/mgk_4",
-			"guns/reload/mg/mgk_5"
+            "guns/reload/mg/mgk_1.ogg",
+			"guns/reload/mg/mgk_2.ogg",
+			"guns/reload/mg/mgk_3.ogg",
+			"guns/reload/mg/mgk_4.ogg",
+			"guns/reload/mg/mgk_5.ogg"
         ]
     },
     {

--- a/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_223.json
+++ b/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_223.json
@@ -90,11 +90,11 @@
         "volume" : 75,
         "variant" : "l_base_223",
         "files" : [
-            "guns/reload/rifle_m/rifle_1",
-			"guns/reload/rifle_m/rifle_2",
-			"guns/reload/rifle_m/rifle_3",
-			"guns/reload/rifle_m/rifle_4",
-			"guns/reload/rifle_m/rifle_5"
+            "guns/reload/rifle_m/rifle_1.ogg",
+			"guns/reload/rifle_m/rifle_2.ogg",
+			"guns/reload/rifle_m/rifle_3.ogg",
+			"guns/reload/rifle_m/rifle_4.ogg",
+			"guns/reload/rifle_m/rifle_5.ogg"
         ]
     },
     {
@@ -139,11 +139,11 @@
         "volume" : 75,
         "variant" : "l_car_223",
         "files" : [
-            "guns/reload/rifle_m/rifle_1",
-			"guns/reload/rifle_m/rifle_2",
-			"guns/reload/rifle_m/rifle_3",
-			"guns/reload/rifle_m/rifle_4",
-			"guns/reload/rifle_m/rifle_5"
+            "guns/reload/rifle_m/rifle_1.ogg",
+			"guns/reload/rifle_m/rifle_2.ogg",
+			"guns/reload/rifle_m/rifle_3.ogg",
+			"guns/reload/rifle_m/rifle_4.ogg",
+			"guns/reload/rifle_m/rifle_5.ogg"
         ]
     },
     {
@@ -188,11 +188,11 @@
         "volume" : 75,
         "variant" : "l_dsr_223",
         "files" : [
-            "guns/reload/rifle_m/rifle_1",
-			"guns/reload/rifle_m/rifle_2",
-			"guns/reload/rifle_m/rifle_3",
-			"guns/reload/rifle_m/rifle_4",
-			"guns/reload/rifle_m/rifle_5"
+            "guns/reload/rifle_m/rifle_1.ogg",
+			"guns/reload/rifle_m/rifle_2.ogg",
+			"guns/reload/rifle_m/rifle_3.ogg",
+			"guns/reload/rifle_m/rifle_4.ogg",
+			"guns/reload/rifle_m/rifle_5.ogg"
         ]
     },
     {

--- a/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_460.json
+++ b/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_460.json
@@ -127,11 +127,11 @@
         "volume" : 75,
         "variant" : "l_enforcer_45",
         "files" : [
-            "guns/reload/revolver/revolver_1",
-			"guns/reload/revolver/revolver_2",
-			"guns/reload/revolver/revolver_3",
-			"guns/reload/revolver/revolver_4",
-			"guns/reload/revolver/revolver_5"
+            "guns/reload/revolver/revolver_1.ogg",
+			"guns/reload/revolver/revolver_2.ogg",
+			"guns/reload/revolver/revolver_3.ogg",
+			"guns/reload/revolver/revolver_4.ogg",
+			"guns/reload/revolver/revolver_5.ogg"
         ]
     },
     {

--- a/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_460.json
+++ b/Otopack+ModsUpdates BN/Mods/ExoticAmmos/exotic_460.json
@@ -172,11 +172,11 @@
         "volume" : 75,
         "variant" : "l_long_45",
         "files" : [
-            "guns/reload/revolver/revolver_1",
-			"guns/reload/revolver/revolver_2",
-			"guns/reload/revolver/revolver_3",
-			"guns/reload/revolver/revolver_4",
-			"guns/reload/revolver/revolver_5"
+            "guns/reload/revolver/revolver_1.ogg",
+			"guns/reload/revolver/revolver_2.ogg",
+			"guns/reload/revolver/revolver_3.ogg",
+			"guns/reload/revolver/revolver_4.ogg",
+			"guns/reload/revolver/revolver_5.ogg"
         ]
     }
 ]

--- a/Otopack+ModsUpdates BN/Mods/Expanded_Archery/Crossbows.json
+++ b/Otopack+ModsUpdates BN/Mods/Expanded_Archery/Crossbows.json
@@ -73,9 +73,9 @@
         "volume" : 75,
         "variant" : "pneu_sniper",
         "files" : [
-            "guns/others/hellsing_1",
-			"guns/others/hellsing_2",
-			"guns/others/hellsing_3"
+            "guns/others/hellsing_1.ogg",
+			"guns/others/hellsing_2.ogg",
+			"guns/others/hellsing_3.ogg"
         ]
     },
 	{
@@ -84,9 +84,9 @@
         "volume" : 40,
         "variant" : "pneu_sniper",
         "files" : [
-            "guns/others/hellsing_1",
-			"guns/others/hellsing_2",
-			"guns/others/hellsing_3"
+            "guns/others/hellsing_1.ogg",
+			"guns/others/hellsing_2.ogg",
+			"guns/others/hellsing_3.ogg"
         ]
     },
     {


### PR DESCRIPTION
Found that the L2031 was spamming error messages on reload due to an NPC that just happened to have one, cause was missing .ogg in the sound defs.

Tested in playthrough build and no more errors when the guy reloads. :3
<img width="1053" height="483" alt="image" src="https://github.com/user-attachments/assets/d31efe84-3387-446d-9941-ffb319d784bf" />

Then along the way I started searching and found more examples to fix.